### PR TITLE
fix: support CJK/unicode characters in portal TitleForUrl routing

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"fmt"
+	"hash/fnv"
 	"regexp"
 	"strings"
 )
@@ -44,8 +46,17 @@ func (p Portal) IsExternal() bool {
 var /* const */ alphaNumDashOnlyRegex = regexp.MustCompile("[^a-zA-Z0-9-]")
 
 // TitleForUrl returns the portal's title with alpha-numerical (and dash) characters only.
+// If the cleaned result is empty (e.g., pure CJK characters), a deterministic
+// hash-based fallback is returned to ensure a valid and unique URL segment.
 func (portal Portal) TitleForUrl() string {
-	return alphaNumDashOnlyRegex.ReplaceAllString(portal.Title, "")
+	cleaned := alphaNumDashOnlyRegex.ReplaceAllString(portal.Title, "")
+	if cleaned != "" {
+		return cleaned
+	}
+	// FNV-64a hash produces a deterministic short string for non-Latin titles.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(portal.Title))
+	return fmt.Sprintf("p-%x", h.Sum64())
 }
 
 // Page struct defines a custom page that consists of a heading, content and a path,

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -61,3 +61,43 @@ func TestTitleForUrl_PreservesDashes(t *testing.T) {
 		t.Fatalf("TitleForUrl() == %q, want %q", got, "my-cool-site")
 	}
 }
+
+func TestTitleForUrl_ChineseCharacters(t *testing.T) {
+	p := Portal{Title: "中国国家地理"}
+	got := p.TitleForUrl()
+	if got == "" {
+		t.Fatal("TitleForUrl() returned empty string for Chinese title")
+	}
+}
+
+func TestTitleForUrl_ChineseWithColon(t *testing.T) {
+	p := Portal{Title: "导航: 首页"}
+	got := p.TitleForUrl()
+	if got == "" {
+		t.Fatal("TitleForUrl() returned empty string for Chinese title with colon")
+	}
+}
+
+func TestTitleForUrl_EmojiOnly(t *testing.T) {
+	p := Portal{Title: "🍳🍕"}
+	got := p.TitleForUrl()
+	if got == "" {
+		t.Fatal("TitleForUrl() returned empty string for emoji-only title")
+	}
+}
+
+func TestTitleForUrl_FallbackIsDeterministic(t *testing.T) {
+	p1 := Portal{Title: "中国国家地理"}
+	p2 := Portal{Title: "中国国家地理"}
+	if p1.TitleForUrl() != p2.TitleForUrl() {
+		t.Fatal("TitleForUrl() should be deterministic for the same input")
+	}
+}
+
+func TestTitleForUrl_HashDiffersForDifferentInputs(t *testing.T) {
+	p1 := Portal{Title: "中国国家地理"}
+	p2 := Portal{Title: "故宫博物院"}
+	if p1.TitleForUrl() == p2.TitleForUrl() {
+		t.Fatal("TitleForUrl() should produce different output for different Chinese titles")
+	}
+}

--- a/internal/server/portal_handler.go
+++ b/internal/server/portal_handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -19,11 +20,17 @@ type portalHandlerInfo struct {
 
 func (p portalHandler) handle() []portalHandlerInfo {
 	portalHandlerInfos := make([]portalHandlerInfo, 0)
+	seen := make(map[string]int)
 	for _, portal := range config.C.Portals {
 		if portal.IsExternal() {
 			fixedTitleUrl := portal.TitleForUrl()
 			if fixedTitleUrl != portal.Title {
 				slog.Debug("fixed title", "old", portal.Title, "new", fixedTitleUrl)
+			}
+			// Ensure unique route paths by deduplicating
+			seen[fixedTitleUrl]++
+			if seen[fixedTitleUrl] > 1 {
+				fixedTitleUrl = fmt.Sprintf("%s-%d", fixedTitleUrl, seen[fixedTitleUrl])
 			}
 			if config.C.EnableMetrics {
 				// Required to initialize all portal metrics to "0".


### PR DESCRIPTION
## Problem

`TitleForUrl()` strips all non-`[a-zA-Z0-9-]` characters. Pure CJK
titles (e.g. 中国国家地理, 故宫博物院) return an empty string, causing every such
portal to register at `/` — colliding with the home route and crashing
the server on startup.

## Solution

1. **FNV-64a hash fallback** in `TitleForUrl()`: when the regex-cleaned
   result is empty, generate a deterministic `p-<hex>` URL segment.
   ASCII titles are unaffected (backward compatible).

2. **Duplicate route detection** in `portal_handler.go`: a `seen` map
   appends `-2`, `-3` suffixes for any remaining hash collisions or
   identical titles.

## Tests

Added 5 test cases: Chinese, Chinese+colon, emoji-only, deterministic
fallback, different-inputs-different-output. All existing tests pass.